### PR TITLE
Bugfixes

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -5,6 +5,7 @@ from torchaudio.transforms import PadTrim
 from fastai.data_block import ItemBase
 from fastai.vision import Image
 import numpy as np
+import torch
 
 AUDIO_EXTENSIONS = tuple(str.lower(k) for k, v in mimetypes.types_map.items()
                          if v.startswith('audio/'))
@@ -34,7 +35,14 @@ class AudioItem(ItemBase):
 
     def show(self, title: [str] = None, **kwargs):
         self.hear(title=title)
-        if self.spectro is not None: display(Image(self.spectro))
+        sg = self.spectro
+        if sg is not None: 
+            if torch.all(torch.eq(sg[0], sg[1])) and torch.all(torch.eq(sg[0], sg[2])):
+                display(Image(sg[0].unsqueeze(0)))
+            else: 
+                display(Image(sg[0].unsqueeze(0)))
+                display(Image(sg[1].unsqueeze(0)))
+                display(Image(sg[2].unsqueeze(0)))
 
     def hear(self, title=None):
         if title is not None: print(title)

--- a/audio/data.py
+++ b/audio/data.py
@@ -31,7 +31,7 @@ class SpectrogramConfig:
     f_max: int = 8000
     pad: int = 0
     n_mels: int = 224
-    standardize: bool = False
+    
 
 @dataclass
 class AudioTransformConfig:
@@ -48,8 +48,10 @@ class AudioTransformConfig:
     segment_size: int = None
     silence_threshold: int = 20
     max_to_pad: float = None
-    sg_cfg = SpectrogramConfig()
     resample_to: int = None
+    standardize: bool = False
+    sg_cfg = SpectrogramConfig()
+    
     
 
 def get_cache(config, cache_type, hash_params):
@@ -167,7 +169,7 @@ class AudioList(ItemList):
             image_path = cache_dir/(f"{s}.pt")
             if cfg.cache and not cfg.force_cache and image_path.exists():
                 mel = torch.load(image_path).squeeze()
-                if cfg.sg_cfg.standardize: mel = standardize(mel)
+                if cfg.standardize: mel = standardize(mel)
                 stacked = mel.expand(3,-1,-1)
                 return AudioItem(spectro=stacked, path=item, max_to_pad=cfg.max_to_pad)
 
@@ -185,7 +187,7 @@ class AudioList(ItemList):
             if cfg.cache:
                 os.makedirs(image_path.parent, exist_ok=True)
                 torch.save(mel, image_path)
-            if cfg.sg_cfg.standardize: mel = standardize(mel)
+            if cfg.standardize: mel = standardize(mel)
             stacked = mel.expand(3,-1,-1)
         return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=stacked, path=item)
 

--- a/audio/data.py
+++ b/audio/data.py
@@ -170,8 +170,8 @@ class AudioList(ItemList):
             if cfg.cache and not cfg.force_cache and image_path.exists():
                 mel = torch.load(image_path).squeeze()
                 if cfg.standardize: mel = standardize(mel)
-                stacked = mel.expand(3,-1,-1)
-                return AudioItem(spectro=stacked, path=item, max_to_pad=cfg.max_to_pad)
+                mel = mel.expand(3,-1,-1)
+                return AudioItem(spectro=mel, path=item, max_to_pad=cfg.max_to_pad)
 
         signal, samplerate = torchaudio.load(str(p))
 
@@ -188,8 +188,8 @@ class AudioList(ItemList):
                 os.makedirs(image_path.parent, exist_ok=True)
                 torch.save(mel, image_path)
             if cfg.standardize: mel = standardize(mel)
-            stacked = mel.expand(3,-1,-1)
-        return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=stacked, path=item)
+            mel = mel.expand(3,-1,-1)
+        return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=mel, path=item)
 
     def get(self, i):
         item = self.items[i]

--- a/audio/data.py
+++ b/audio/data.py
@@ -70,8 +70,9 @@ def make_cache(sigs, sr, config, cache_type, hash_params):
             torchaudio.save(str(fn), s, sr)
     return files
 
-def resample_item(item, config):
+def resample_item(item, config, path):
     item_path, label = item
+    if not os.path.exists(item_path): item_path = path/item_path
     sr_new = config.resample_to
     files = get_cache(config, "rs", [item_path, sr_new])
     if not files:
@@ -80,8 +81,9 @@ def resample_item(item, config):
         files = make_cache(sig, sr_new, config, "rs", [item_path, sr_new])
     return list(zip(files, [label]*len(files)))
 
-def remove_silence(item, config):
+def remove_silence(item, config, path):
     item_path, label = item
+    if not os.path.exists(item_path): item_path = path/item_path
     st, sp = config.silence_threshold, config.silence_padding
     files = get_cache(config, "sh", [item_path, st, sp])
     if not files:
@@ -90,8 +92,9 @@ def remove_silence(item, config):
         files = make_cache(sigs, sr, config, "sh", [item_path, st, sp])
     return list(zip(files, [label]*len(files)))
 
-def segment_items(item, config):
+def segment_items(item, config, path):
     item_path, label = item
+    if not os.path.exists(item_path): item_path = path/item_path
     sig, sr = torchaudio.load(item_path)
     segsize = int(config.segment_size / 1000 * sr)
     files = get_cache(config, "s", [item_path, segsize, label])
@@ -115,15 +118,15 @@ class AudioLabelList(LabelList):
                 (x, y)) if len(y) > 0 else x
             
             if x.config.resample_to:
-                items = [resample_item(i, x.config) for i in items]
+                items = [resample_item(i, x.config, x.path) for i in items]
                 items = reduce(concat, items, np.empty((0, 2)))
 
             if x.config.remove_silence:
-                items = [remove_silence(i, x.config) for i in items]
+                items = [remove_silence(i, x.config, x.path) for i in items]
                 items = reduce(concat, items, np.empty((0, 2)))
 
             if x.config.segment_size:
-                items = [segment_items(i, x.config) for i in items]
+                items = [segment_items(i, x.config, x.path) for i in items]
                 items = reduce(concat, items, np.empty((0, 2)))
 
             nx, ny = tuple(zip(*items))
@@ -150,7 +153,9 @@ class AudioList(ItemList):
 
     def open(self, item) -> AudioItem:
         p = Path(item)
-        if not p.exists():                                raise Exception('File not found: ' + str(p))
+        if not p.exists(): 
+            p = self.path/item
+            if not p.exists(): raise FileNotFoundError(f"Neither '{item}' nor '{p}' could be found")
         if not str(p).lower().endswith(AUDIO_EXTENSIONS): raise Exception("Invalid audio file")
 
         cfg = self.config
@@ -159,8 +164,9 @@ class AudioList(ItemList):
             s = md5(str(asdict(cfg)) + str(p))
             image_path = cache_dir/(f"{s}.pt")
             if cfg.cache and not cfg.force_cache and image_path.exists():
-                spectro = torch.load(image_path)
-                return AudioItem(spectro=spectro, path=item, max_to_pad=cfg.max_to_pad)
+                spectro = torch.load(image_path).squeeze()
+                stacked = mono_to_color(spectro)
+                return AudioItem(spectro=stacked, path=item, max_to_pad=cfg.max_to_pad)
 
         signal, samplerate = torchaudio.load(str(p))
 
@@ -170,13 +176,14 @@ class AudioList(ItemList):
         mel = None
         if cfg.use_spectro:
             mel = MelSpectrogram(**asdict(cfg.sg_cfg))(signal.reshape(1, -1))
-            mel = mel.permute(0, 2, 1)
+            mel = mel.permute(0, 2, 1).squeeze()
             if cfg.to_db_scale:
                 mel = SpectrogramToDB(top_db=cfg.top_db)(mel)
             if cfg.cache:
                 os.makedirs(image_path.parent, exist_ok=True)
                 torch.save(mel, image_path)
-        return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=mel, path=item)
+            stacked = mono_to_color(mel)
+        return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=stacked, path=item)
 
     def get(self, i):
         item = self.items[i]

--- a/audio/data.py
+++ b/audio/data.py
@@ -150,7 +150,7 @@ class AudioList(ItemList):
 
     def open(self, item) -> AudioItem:
         p = Path(item)
-        if not p.exists():                                raise Exception('File not found: ' + p)
+        if not p.exists():                                raise Exception('File not found: ' + str(p))
         if not str(p).lower().endswith(AUDIO_EXTENSIONS): raise Exception("Invalid audio file")
 
         cfg = self.config

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -3,10 +3,10 @@ from .data import *
 def audio_learner(data:DataBunch, base_arch:Callable=models.resnet18, metrics=accuracy, **kwargs):
     '''Wrapper function for fastai learner. Converts head of model to fit one channel input.'''
     learn = cnn_learner(data, base_arch, metrics=metrics, **kwargs)
-    newlayer = nn.Conv2d(1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
-    newlayer = newlayer.cuda() # Our layer should use cuda, since the rest of the model will.
-    learn.model[0][0] = newlayer
-    learn.unfreeze()
+    #newlayer = nn.Conv2d(1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
+    #newlayer = newlayer.cuda() # Our layer should use cuda, since the rest of the model will.
+    #learn.model[0][0] = newlayer
+    #learn.unfreeze()
     return learn
 
 def audio_predict(learn, item:AudioItem):

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -1,5 +1,11 @@
 from .data import *
 
+#wrapper for cnn learner that does nothing, but will be used in the future for handling raw waveform (1D) inputs.
+def audio_learner(data:DataBunch, base_arch:Callable=models.resnet18, metrics=accuracy, **kwargs):
+    '''Wrapper function for fastai learner. Converts head of model to fit one channel input.'''
+    learn = cnn_learner(data, base_arch, metrics=metrics, **kwargs)
+    return learn
+
 def audio_predict(learn, item:AudioItem):
     '''Applies the AudioTransforms to the item before predicting its class'''
     config = learn.data.x.config

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -1,14 +1,5 @@
 from .data import *
 
-def audio_learner(data:DataBunch, base_arch:Callable=models.resnet18, metrics=accuracy, **kwargs):
-    '''Wrapper function for fastai learner. Converts head of model to fit one channel input.'''
-    learn = cnn_learner(data, base_arch, metrics=metrics, **kwargs)
-    #newlayer = nn.Conv2d(1, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
-    #newlayer = newlayer.cuda() # Our layer should use cuda, since the rest of the model will.
-    #learn.model[0][0] = newlayer
-    #learn.unfreeze()
-    return learn
-
 def audio_predict(learn, item:AudioItem):
     '''Applies the AudioTransforms to the item before predicting its class'''
     config = learn.data.x.config

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -13,6 +13,28 @@ from librosa.effects import split
 from torchaudio import transforms
 from scipy.signal import resample_poly
 
+#Code altered from a kaggle kernel shared by @daisukelab
+def mono_to_color(X, mean=None, std=None, norm_max=None, norm_min=None, eps=1e-6):
+    # Standardize
+#     mean = mean or X.mean()
+#     std = std or X.std()
+#     Xstd = (X - mean) / (std + eps)
+#     _min, _max = Xstd.min(), Xstd.max()
+#     norm_max = norm_max or _max
+#     norm_min = norm_min or _min
+#     # Scale to [0, 1]
+#     if (_max - _min) > eps:
+#         V = Xstd
+#         V[V < norm_min] = norm_min
+#         V[V > norm_max] = norm_max
+#         V = (V - norm_min) / (norm_max - norm_min)
+
+#     else: V = torch.zeros_like(Xstd)
+    #Equivalent to torch.stack[X,X,X] for 3 channels, but does so using shared memory
+    V=X
+    V = V.expand(3, -1, -1)
+    return V
+
 def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
     '''Shifts spectrogram along x-axis wrapping around to other side'''
     if len(spectro.shape) < 2:

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -11,6 +11,7 @@ import librosa
 import torchaudio
 from librosa.effects import split
 from torchaudio import transforms
+from scipy.signal import resample_poly
 
 def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
     '''Shifts spectrogram along x-axis wrapping around to other side'''

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -13,26 +13,23 @@ from librosa.effects import split
 from torchaudio import transforms
 from scipy.signal import resample_poly
 
-#Code altered from a kaggle kernel shared by @daisukelab
-def mono_to_color(X, mean=None, std=None, norm_max=None, norm_min=None, eps=1e-6):
-    # Standardize
-#     mean = mean or X.mean()
-#     std = std or X.std()
-#     Xstd = (X - mean) / (std + eps)
-#     _min, _max = Xstd.min(), Xstd.max()
-#     norm_max = norm_max or _max
-#     norm_min = norm_min or _min
-#     # Scale to [0, 1]
-#     if (_max - _min) > eps:
-#         V = Xstd
-#         V[V < norm_min] = norm_min
-#         V[V > norm_max] = norm_max
-#         V = (V - norm_min) / (norm_max - norm_min)
 
-#     else: V = torch.zeros_like(Xstd)
-    #Equivalent to torch.stack[X,X,X] for 3 channels, but does so using shared memory
-    V=X
-    V = V.expand(3, -1, -1)
+#Code altered from a kaggle kernel shared by @daisukelab, scales a spectrogram
+#to be floats between 0 and 1 as this is how most 3 channel images are handled
+def standardize(mel, mean=None, std=None, norm_max=None, norm_min=None, eps=1e-6):
+    mean = mean or mel.mean()
+    std = std or mel.std()
+    mel_std = (mel - mean) / (std + eps)
+    _min, _max = mel_std.min(), mel_std.max()
+    norm_max = norm_max or _max
+    norm_min = norm_min or _min
+    # Scale to [0, 1]
+    if (_max - _min) > eps:
+        V = mel_std
+        V[V < norm_min] = norm_min
+        V[V > norm_max] = norm_max
+        V = (V - norm_min) / (norm_max - norm_min)
+    else: V = torch.zeros_like(mel_std)    
     return V
 
 def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):


### PR DESCRIPTION
This and the MFCC (coming next) are my last messy PRs. This update fixes a few small known issues, but the main change is previously we were altering the head of resnets to accept 1 channel input, this means we can't use other architectures. To fix it, I removed the audio learner, and copied the 1 channel input into 3 channels of shared memory (torch.expand). I also added the option (off by default) to standardize and move sg values (normal dB values between -0 and -top_db, to the scale of [0, 1]. Finally this update fixes AudioItem.show() to display 1 channel if all 3 channels are equal, and all 3 channels if any of the channels are unique. 