### PR TITLE
Mfcc feature

### DIFF
--- a/audio/data.py
+++ b/audio/data.py
@@ -52,6 +52,7 @@ class AudioTransformConfig:
     standardize: bool = False
     sg_cfg = SpectrogramConfig()
     mfcc: bool = False
+    delta: bool = False
     
 def get_cache(config, cache_type, hash_params):
     if not config.cache_dir: return None
@@ -184,7 +185,9 @@ class AudioList(ItemList):
                 if cfg.to_db_scale: mel = SpectrogramToDB(top_db=cfg.top_db)(mel)
             mel = mel.squeeze().permute(1, 0)
             if cfg.standardize: mel = standardize(mel)
-            mel = mel.expand(3,-1,-1)
+                
+            if cfg.delta: mel = torch.stack([mel, torchdelta(mel), torchdelta(mel, order=2)]) 
+            else: mel = mel.expand(3,-1,-1)
             if cfg.cache:
                 os.makedirs(image_path.parent, exist_ok=True)
                 torch.save(mel, image_path)

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -32,6 +32,9 @@ def standardize(mel, mean=None, std=None, norm_max=None, norm_min=None, eps=1e-6
     else: V = torch.zeros_like(mel_std)    
     return V
 
+def torchdelta(mel, order=1):
+    return torch.from_numpy(librosa.feature.delta(mel.numpy(), order=order))
+
 def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
     '''Shifts spectrogram along x-axis wrapping around to other side'''
     if len(spectro.shape) < 2:

--- a/tests/test_audio_data.py
+++ b/tests/test_audio_data.py
@@ -34,7 +34,7 @@ def test_cache_resample(random_item):
     path_resample = config.cache_dir / f"sh_{md5(str(p)+str(rs))}"
     if os.path.exists(path_resample): os.remove(path_resample)
     assert not os.path.exists(path_resample)
-    files = resample_item(item, config)
+    files = resample_item(item, config, p)
     for f, _ in files:
         assert os.path.exists(f)
         assert os.path.isfile(f)
@@ -47,7 +47,7 @@ def test_cache_silence(random_item):
     config = AudioTransformConfig(cache=True, silence_threshold=st, silence_padding=sp)
     item = (p, "Label Not Important")
     path_silence = config.cache_dir / f"sh_{md5(str(p)+str(st)+str(sp))}"
-    files = remove_silence(item, config)
+    files = remove_silence(item, config, p)
     for f, _ in files:
         assert os.path.exists(f)
         assert os.path.isfile(f)
@@ -61,10 +61,11 @@ def test_cache_segment(random_item):
     label = "Label Not Important"
     item = (p, label)
     path_segment = config.cache_dir / f"s_{md5(str(p)+str(segsize)+str(label))}"
-    files = segment_items(item, config)
+    files = segment_items(item, config, p)
     for f, _ in files:
         assert os.path.exists(f)
         assert os.path.isfile(f)
         assert torchaudio.load(f)
-    
+        
+        
 #def test_cache_read(path):


### PR DESCRIPTION
Add MFCC (mel-frequency cepstral coefficient) generation (turn on by setting mfcc=True in config) as an alternative option to melspectrogram. It is already torchified thanks to torchaudio people. We can add additional spectral features via librosa but we then have to convert to numpy, caching should help though. 

I also added delta/accelerate stacking options (turn on by setting delta=True in config). Instead of copying the spectrogram or MFCC to 3 channels, this instead uses the 1st and 2nd derivative of the spectrogram (a somewhat common practice in AudioML) for the 2nd and 3rd channels. These are cached as well if cache option is on because they take several ms to convert to numpy, generate, and convert back to torch. 