### PR TITLE
Duration

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -11,7 +11,7 @@ AUDIO_EXTENSIONS = tuple(str.lower(k) for k, v in mimetypes.types_map.items()
                          if v.startswith('audio/'))
 
 class AudioItem(ItemBase):
-    def __init__(self, sig=None, sr=None, path=None, spectro=None, max_to_pad=None):
+    def __init__(self, sig=None, sr=None, path=None, spectro=None, max_to_pad=None, sg_duration=None):
         '''Holds Audio signal and/or specrogram data'''
         if(isinstance(sig, np.ndarray)): sig = torch.from_numpy(sig).unsqueeze(0)
         self._sig, self._sr, self.path, self.spectro = sig, sr, path, spectro

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -35,7 +35,9 @@ class AudioItem(ItemBase):
             return AudioItem(item)
 
     def show(self, title: [str] = None, **kwargs):
+        print(f"File: {self.path}")
         self.hear(title=title)
+        
         sg = self.spectro
         if sg is not None: 
             if torch.all(torch.eq(sg[0], sg[1])) and torch.all(torch.eq(sg[0], sg[2])):
@@ -47,7 +49,15 @@ class AudioItem(ItemBase):
 
     def hear(self, title=None):
         if title is not None: print(title)
-        display(self.ipy_audio)
+        
+        if self.start is not None or self.end is not None:
+            print(f"{round(self.start/self.sr, 2)}s-{round(self.end/self.sr,2)}s of original clip")
+            start = 0 if self.start is None else self.start
+            end = len(self.sig)-1 if self.end is None else self.end
+            display(Audio(data=self.sig[start:end], rate=self.sr))
+        else:
+            display(self.ipy_audio)
+        
 
     def apply_tfms(self, tfms):
         for tfm in tfms:
@@ -58,10 +68,7 @@ class AudioItem(ItemBase):
     def shape(self): return self.data.shape
 
     def _reload_signal(self):
-        if self.start is not None and self.end is not None: 
-            sig, sr = torchaudio.load(self.path, offset=self.start, num_frames=self.end-self.start)
-        else:
-            sig, sr = torchaudio.load(self.path)
+        sig, sr = torchaudio.load(self.path)
         if self.max_to_pad is not None:
             sig = PadTrim(max_len=int(self.max_to_pad/1000*sr))(sig)
         self._sr = sr

--- a/audio/data.py
+++ b/audio/data.py
@@ -34,7 +34,7 @@ class SpectrogramConfig:
     
 
 @dataclass
-class AudioTransformConfig:
+class AudioConfig:
     '''Options for pre-processing audio signals'''
     sg_duration: int = None
     remove_silence: bool = False
@@ -62,7 +62,6 @@ def get_cache(config, cache_type, item_path, params):
     details = "-".join(map(str, params))
     top_level = config.cache_dir / f"{cache_type}_{details}"
     subfolder = f"{item_path.name}-{md5(str(item_path))}"
-    #subfolder = f"{md5(str(item_path))}-{item_path.name}"
     mark = top_level/subfolder
     files = get_files(mark) if mark.exists() else None
     return files
@@ -71,7 +70,6 @@ def make_cache(sigs, sr, config, cache_type, item_path, params):
     details = "-".join(map(str, params))
     top_level = config.cache_dir / f"{cache_type}_{details}"
     subfolder = f"{item_path.name}-{md5(str(item_path))}"
-    #subfolder = f"{md5(str(item_path))}-{item_path.name}"
     mark = top_level/subfolder
     files = []
     if len(sigs) > 0:
@@ -161,9 +159,9 @@ class AudioLabelList(LabelList):
 
 class AudioList(ItemList):
     _bunch = AudioDataBunch
-    config: AudioTransformConfig
+    config: AudioConfig
 
-    def __init__(self, items, path, config=AudioTransformConfig(), **kwargs):
+    def __init__(self, items, path, config=AudioConfig(), **kwargs):
         super().__init__(items, path, **kwargs)
         self._label_list = AudioLabelList
         config.cache_dir = path / config.cache_dir

--- a/audio/data.py
+++ b/audio/data.py
@@ -36,6 +36,7 @@ class SpectrogramConfig:
 @dataclass
 class AudioTransformConfig:
     '''Options for pre-processing audio signals'''
+    sg_duration: int = None
     remove_silence: bool = False
     use_spectro: bool = True
     cache: bool = True
@@ -54,6 +55,7 @@ class AudioTransformConfig:
     mfcc: bool = False
     n_mfcc: int = 20
     delta: bool = False
+    _sr = None
     
 def get_cache(config, cache_type, item_path, params):
     if not config.cache_dir: return None
@@ -117,11 +119,16 @@ def segment_items(item, config, path):
         files = make_cache(sigs, sr, config, "s", item_path, [config.segment_size])
     return list(zip(files, [label]*len(files)))
 
+def _set_sr(item_path, config):
+    sig, sr = torchaudio.load(item_path)
+    config._sr = sr
+
 class AudioLabelList(LabelList):
 
     def _pre_process(self):
         x, y = self.x, self.y
         cfg = x.config
+        if not cfg.resample_to: _set_sr(x.items[0], x.config)
         if len(x.items) > 0 and (cfg.remove_silence or cfg.segment_size or cfg.resample_to):
             items = list(zip(x.items, y.items))
 
@@ -129,6 +136,7 @@ class AudioLabelList(LabelList):
                 (x, y)) if len(y) > 0 else x
             
             if x.config.resample_to:
+                cfg._sr = x.config.resample_to
                 items = [resample_item(i, x.config, x.path) for i in items]
                 items = reduce(concat, items, np.empty((0, 2)))
 
@@ -177,10 +185,15 @@ class AudioList(ItemList):
             image_path = cache_dir/(f"{folder}/{fname}")
             if cfg.cache and not cfg.force_cache and image_path.exists():
                 mel = torch.load(image_path).squeeze()
-                if cfg.standardize: mel = standardize(mel)
+                if cfg.sg_duration: mel= tfm_sg_crop(mel, cfg.sg_duration, cfg._sr, cfg.sg_cfg.hop)
                 return AudioItem(spectro=mel, path=item, max_to_pad=cfg.max_to_pad)
 
         signal, samplerate = torchaudio.load(str(p))
+        if(cfg._sr is not None and samplerate != cfg._sr):
+            raise ValueError(f'''Multiple sample rates detected. Sample rate {samplerate} of file {str(p)} 
+                                does not match config sample rate {cfg._sr} 
+                                this means your dataset has multiple different sample rates, 
+                                please choose one and set resample_to to that value''')
 
         if cfg.max_to_pad or cfg.segment_size:
             pad_len = cfg.max_to_pad if cfg.max_to_pad is not None else cfg.segment_size
@@ -199,7 +212,7 @@ class AudioList(ItemList):
             if cfg.cache:
                 os.makedirs(image_path.parent, exist_ok=True)
                 torch.save(mel, image_path)
-
+            if cfg.sg_duration: mel = tfm_sg_crop(mel, cfg.sg_duration, cfg._sr, cfg.sg_cfg.hop)
         return AudioItem(sig=signal.squeeze(), sr=samplerate, spectro=mel, path=item)
 
     def get(self, i):

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -13,4 +13,7 @@ def audio_predict(learn, item:AudioItem):
     al = AudioList([item], path, config=config).split_none().label_empty()
     res = torch.tensor([learn.predict(ai)[1] for ai in al.x])
     return learn.data.y.classes[torch.max(res)]
+
+def window_predict(learn, item:AudioItem, cfg, hop):
+    display(item.spectro)
     

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -67,31 +67,31 @@ def tfm_sg_crop(spectro, crop_duration, sr, hop):
 
 def tfm_mask_time(spectro, tmasks=1, num_cols=20, start_col=None, tmask_value=None, **kwargs):
     '''Google SpecAugment time masking from https://arxiv.org/abs/1904.08779.'''
-    sg = spectro.clone().squeeze(0)
+    sg = spectro.clone()
     mask_value = sg.mean() if tmask_value is None else tmask_value
-    x, y = sg.shape
+    c, y, x  = sg.shape
     for _ in range(tmasks):
-        mask = torch.ones(x, num_cols) * mask_value
-        if start_col is None: start_col = random.randint(0, y-num_cols)
-        if not 0 <= start_col <= y-num_cols: 
+        mask = torch.ones(y, num_cols) * mask_value
+        if start_col is None: start_col = random.randint(0, x-num_cols)
+        if not 0 <= start_col <= x-num_cols: 
             raise ValueError(f"start_col value '{start_col}' out of range for sg of shape {sg.shape}")
-        sg[:,start_col:start_col+num_cols] = mask
+        sg[:,:,start_col:start_col+num_cols] = mask
         start_col = None
-    return sg.unsqueeze(0)
+    return sg
 
 def tfm_mask_frequency(spectro, fmasks=1, num_rows=30, start_row=None, fmask_value=None, **kwargs):
     '''Google SpecAugment frequency masking from https://arxiv.org/abs/1904.08779.'''
-    sg = spectro.clone().squeeze(0)
+    sg = spectro.clone()
     mask_value = sg.mean() if fmask_value is None else fmask_value
-    x, y = sg.shape
+    c, y, x = sg.shape
     for _ in range(fmasks):
-        mask = torch.ones(num_rows, y) * mask_value
-        if start_row is None: start_row = random.randint(0, x-num_rows)
-        if not 0 <= start_row <= x-num_rows: 
+        mask = torch.ones(num_rows, x) * mask_value
+        if start_row is None: start_row = random.randint(0, y-num_rows)
+        if not 0 <= start_row <= y-num_rows: 
             raise ValueError(f"start_row value '{start_row}' out of range for sg of shape {sg.shape}")
-        sg[start_row:start_row+num_rows,:] = mask
+        sg[:,start_row:start_row+num_rows,:] = mask
         start_hori = None
-    return sg.unsqueeze(0)
+    return sg
 
 def get_spectro_transforms(mask_time:bool=True,
                            mask_frequency:bool=True,

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -94,7 +94,8 @@ def tfm_mask_frequency(spectro, fmasks=1, num_rows=30, start_row=None, fmask_val
         start_hori = None
     return sg
 
-def get_spectro_transforms(mask_time:bool=True,
+def get_spectro_transforms(cfg: AudioConfig,
+                           mask_time:bool=True,
                            mask_frequency:bool=True,
                            roll:bool=True,
                            xtra_tfms:Optional[Collection[Transform]]=None,

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -52,6 +52,19 @@ def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
     sg = sg.roll(roll_by, dims=2)
     return sg
 
+def tfm_sg_crop(spectro, crop_duration, sr, hop):
+    if sr is None: return spectro
+    sg = spectro.clone()
+    c, y, x = sg.shape
+    
+    total_duration = (hop*x)/sr
+    if crop_duration >= total_duration: return spectro
+    crop_width = int(x*crop_duration/total_duration)
+    
+    crop_start = random.randint(0, x-crop_width)
+    sg_crop = sg[:,:,crop_start:crop_start+crop_width]
+    return sg_crop
+
 def tfm_mask_time(spectro, tmasks=1, num_cols=20, start_col=None, tmask_value=None, **kwargs):
     '''Google SpecAugment time masking from https://arxiv.org/abs/1904.08779.'''
     sg = spectro.clone().squeeze(0)

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -38,21 +38,8 @@ def torchdelta(mel, order=1, width=9):
         {width} columns, try setting max_to_pad to a larger value to ensure a minimum width''')
     return torch.from_numpy(librosa.feature.delta(mel.numpy(), order=order, width=9))
 
-def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
-    '''Shifts spectrogram along x-axis wrapping around to other side'''
-    if len(spectro.shape) < 2:
-        raise Exception('You are trying to apply the tranform to as signal')
-    if int(direction) not in [-1, 0, 1]: 
-        raise ValueError("Direction must be -1(left) 0(bidirectional) or 1(right)")
-    direction = random.choice([-1, 1]) if direction == 0 else direction
-    
-    sg = spectro.clone()
-    width = sg.shape[1]
-    roll_by = int(width*random.random()*max_shift_pct*direction)
-    sg = sg.roll(roll_by, dims=2)
-    return sg
-
 def tfm_sg_crop(spectro, crop_duration, sr, hop):
+    
     if sr is None: return spectro
     sg = spectro.clone()
     c, y, x = sg.shape
@@ -64,6 +51,20 @@ def tfm_sg_crop(spectro, crop_duration, sr, hop):
     crop_start = random.randint(0, x-crop_width)
     sg_crop = sg[:,:,crop_start:crop_start+crop_width]
     return sg_crop
+
+def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
+    '''Shifts spectrogram along x-axis wrapping around to other side'''
+    if len(spectro.shape) < 2:
+        raise Exception('Cannot apply spectrogram rolling to a signal')
+    if int(direction) not in [-1, 0, 1]: 
+        raise ValueError("Direction must be -1(left) 0(bidirectional) or 1(right)")
+    direction = random.choice([-1, 1]) if direction == 0 else direction
+    
+    sg = spectro.clone()
+    c, height, width = sg.shape
+    roll_by = int(width*random.random()*max_shift_pct*direction)
+    sg = sg.roll(roll_by, dims=2)
+    return sg
 
 def tfm_mask_time(spectro, tmasks=1, num_cols=20, start_col=None, tmask_value=None, **kwargs):
     '''Google SpecAugment time masking from https://arxiv.org/abs/1904.08779.'''

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -38,19 +38,28 @@ def torchdelta(mel, order=1, width=9):
         {width} columns, try setting max_to_pad to a larger value to ensure a minimum width''')
     return torch.from_numpy(librosa.feature.delta(mel.numpy(), order=order, width=9))
 
-def tfm_sg_crop(spectro, crop_duration, sr, hop):
-    
-    if sr is None: return spectro
+def tfm_crop_time(spectro, cfg):
+    sr, crop_duration, hop = cfg._sr, cfg.duration, cfg.sg_cfg.hop
+    if sr is None: return spectro, None, None
     sg = spectro.clone()
     c, y, x = sg.shape
     
     total_duration = (hop*x)/sr
-    if crop_duration >= total_duration: return spectro
-    crop_width = int(x*crop_duration/total_duration)
+    # instead of just returning the spectro here we need to extend it to be the same size as the others
+    # by padding 
+    # also we should change duration to be in ms instead of seconds for consistency
     
+    crop_width = int(sr*crop_duration/hop)
+    if crop_duration >= total_duration: 
+        padding = torch.zeros((c,y, crop_width-x))
+        sg_pad = torch.cat((sg, padding), 2)
+        return sg_pad, None, None
     crop_start = random.randint(0, x-crop_width)
+    
     sg_crop = sg[:,:,crop_start:crop_start+crop_width]
-    return sg_crop
+    start_sample = int(crop_start*hop)
+    end_sample = int(start_sample + crop_duration*sr)
+    return sg_crop, start_sample, end_sample
 
 def tfm_sg_roll(spectro, max_shift_pct=0.7, direction=0, **kwargs):
     '''Shifts spectrogram along x-axis wrapping around to other side'''
@@ -94,19 +103,24 @@ def tfm_mask_frequency(spectro, fmasks=1, num_rows=30, start_row=None, fmask_val
         start_hori = None
     return sg
 
-def get_spectro_transforms(cfg: AudioConfig,
+def get_spectro_transforms(cfg,
+                           crop_time: bool=False,
                            mask_time:bool=True,
                            mask_frequency:bool=True,
                            roll:bool=True,
                            xtra_tfms:Optional[Collection[Transform]]=None,
                          **kwargs)->Collection[Transform]:
     "Utility func to create a list of spectrogram transforms"
-    res = []
-    if mask_time: res.append(partial(tfm_mask_time, **kwargs))
-    if mask_frequency: res.append(partial(tfm_mask_frequency, **kwargs))
-    if roll: res.append(partial(tfm_sg_roll, **kwargs))
+    train = []
+    val = []
+    if crop_time:
+        train.append(partial(tfm_crop_time, cfg=cfg, **kwargs))
+        val.append(partial(tfm_crop_time, cfg=cfg, **kwargs))
+    if mask_time: train.append(partial(tfm_mask_time, **kwargs))
+    if mask_frequency: train.append(partial(tfm_mask_frequency, **kwargs))
+    if roll: train.append(partial(tfm_sg_roll, **kwargs))
     
-    return (res+listify(xtra_tfms), [])
+    return (train+listify(xtra_tfms), val)
 
 def tfm_trim_silence(signal, rate, threshold=20, pad_ms=200):
     '''Remove silence from start and end of audio'''


### PR DESCRIPTION
Add duration (in milliseconds) as an option to config. This will compute cache the spectrogram for the whole of the audio, but if cfg.duration is set to a value (e.g. 2000 = 2s), it will select different 2s chunks of the spectrogram at random for each round of training. The tfm_crop_time function is a bit unique as it passes back "start" and "end" values which are the sample # for the start and end of the clipped portion. This allows display of audio that matches the spectrogram by passing start and end values to the AudioItem. It also allows us to tell the user what portion of the original audio they are listening to. For example if duration is 4000 and the clip is 15s, the cropped spectro will display 4s of audio along with a msg saying "7.2s-11.2s of original clip". 

Also, this type of cropping only happens after preprocessing, so it won't occur to items in an audiolist