### PR TITLE
Reconstruct

### DIFF
--- a/audio/data.py
+++ b/audio/data.py
@@ -315,7 +315,9 @@ class AudioList(ItemList):
             if not ('/') in str(item): return self.open(self.path/item)
             else:                      return self.open(item)
         raise TypeError(f"Can't handle type {type(item)}, only AudioItem, str, Path or PosixPath")  
-        
+    
+    def reconstruct(self, x): return x
+    
     def stats(self, prec=0, devs=3, figsize=(15,5)):
         '''Displays samples, plots file lengths and returns outliers of the AudioList'''
         len_dict = {}

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -6,15 +6,14 @@ def audio_learner(data:DataBunch, base_arch:Callable=models.resnet18, metrics=ac
     return cnn_learner(data, base_arch, metrics=metrics, **kwargs)
 
 def audio_predict(learn, item:AudioItem):
-    '''Applies preprocessing to an AudioItem, or spectrogram before predicting its class'''
-    if(isinstance(item, torch.Tensor)): return learn.predict(item.cpu())
+    '''Applies preprocessing to an AudioItem before predicting its class'''
     al = AudioList([item], path=item.path, config=learn.data.x.config).split_none().label_empty()
-    spectro = AudioList.open(al, item.path).spectro
-    return learn.predict(spectro)                                              
+    ai = AudioList.open(al, item.path)
+    return learn.predict(ai)                                              
 
 def audio_predict_all(learn, al:AudioList):
     '''Applies preprocessing to an AudioList then predicts on all items'''
     al = al.split_none().label_empty()
-    data = [AudioList.open(al, ai[0].path).spectro for ai in al.train]
-    preds = [learn.predict(spectro) for spectro in progress_bar(data)]
+    audioItems = [AudioList.open(al, ai[0].path) for ai in al.train]
+    preds = [learn.predict(ai) for ai in progress_bar(audioItems)]
     return [o for o in zip(*preds)]


### PR DESCRIPTION
Add (default) reconstruct method to AudioList to make exported models work. 
Remove prediction on spectros and replace with AudioItem so valid/testset transforms can be applied