### PR TITLE
Fix remove silence bug when using remove_type of "all"

### DIFF
--- a/audio/transform.py
+++ b/audio/transform.py
@@ -162,7 +162,7 @@ def tfm_remove_silence(signal, rate, remove_type, threshold=20, pad_ms=200):
     elif remove_type == "trim":
         return [actual[(max(splits[0, 0]-padding,0)):splits[-1, -1]+padding].unsqueeze(0)]
     elif remove_type == "all":
-        return [torch.cat([actual[(max(a-padding,0)):(min(b+padding,len(actual)))] for (a, b) in splits])]
+        return [torch.cat([actual[int(max(a-padding/2,0)):int(min(b+padding/2,len(actual)))] for (a, b) in splits])]
     else: 
         raise ValueError(f"Valid options for silence removal are None, 'split', 'trim', 'all' not {remove_type}.")
 


### PR DESCRIPTION
This code change fixes a bug that made remove silence create an audio clip longer than the original clip.  The problem was that for each individual clip created by split, 2*padding was added which is fine when those clips remain independent as is the case with "split", but with "all" the clips are combined and the overlap causes up to a padding length delay to be added for each split.

Fixes: [https://github.com/mogwai/fastai_audio/issues/25](https://github.com/mogwai/fastai_audio/issues/25)
