### PR TITLE
Removing unnecessary import

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -8,7 +8,6 @@ import numpy as np
 import torch
 import warnings
 from pathlib import Path, PosixPath
-from audio import *
 
 
 AUDIO_EXTENSIONS = tuple(str.lower(k) for k, v in mimetypes.types_map.items() if v.startswith('audio/'))


### PR DESCRIPTION
Getting rid of an import that isn't required to make eventual merging into fastai core library easier.

Discussed in this issue: https://github.com/mogwai/fastai_audio/issues/27