### PR TITLE
changing segment_items to improve performance

### DIFF
--- a/audio/data.py
+++ b/audio/data.py
@@ -167,10 +167,10 @@ def remove_silence(item, config, path):
 def segment_items(item, config, path):
     item_path, label = item
     if not os.path.exists(item_path): item_path = path/item_path
-    segsize = int(config._sr*config.segment_size/1000)
     files = get_cache(config, "s", item_path, [config.segment_size])
     if not files:
         sig, sr = torchaudio.load(item_path)
+        segsize = int(config._sr*config.segment_size/1000)
         sig = sig.squeeze()
         sigs = []
         siglen = len(sig)

--- a/audio/data.py
+++ b/audio/data.py
@@ -167,10 +167,10 @@ def remove_silence(item, config, path):
 def segment_items(item, config, path):
     item_path, label = item
     if not os.path.exists(item_path): item_path = path/item_path
-    sig, sr = torchaudio.load(item_path)
-    segsize = int(sr*config.segment_size/1000)
+    segsize = int(config._sr*config.segment_size/1000)
     files = get_cache(config, "s", item_path, [config.segment_size])
     if not files:
+        sig, sr = torchaudio.load(item_path)
         sig = sig.squeeze()
         sigs = []
         siglen = len(sig)


### PR DESCRIPTION
I believe this will speed up reruns when segmenting items.  Basically instead of loading every file, I just look at the sample rate in the config and then move the loading to inside the if that checks if the file is already there.  