### PR TITLE
Upgrade to torchaudio v0.3.0 FastAI 1.0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,14 @@
 
 This is an audio module built on top of FastAI to allow you to quickly and easily build machine learning models for a wide variety of audio applications. We are an unofficial library and have no official connection to fastai except that we are huge fans and want to help make their tools more widely available and applicable to audio.
 
-# Dependencies
-Currently uses Pytorch 1.30, FastAI 1.0.59, Librosa 0.7.1
-```
-conda install -c pytorch -c fastai fastai
-conda install -c pytorch torchaudio
-conda install -c conda-forge librosa
-```
-
-
 # Installation
 To install, run the following commands in a shell. 
 
 ```
 git clone https://github.com/mogwai/fastai_audio
 cd fastai_audio
+sudo chmod +x install.sh
+./install.sh
 ```
 
 If you wish to work in a folder other than fastai_audio, you can link the audio folder by navigating in the terminal to the folder where your notebooks are and running

--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 
 This is an audio module built on top of FastAI to allow you to quickly and easily build machine learning models for a wide variety of audio applications. We are an unofficial library and have no official connection to fastai except that we are huge fans and want to help make their tools more widely available and applicable to audio.
 
+# Dependencies
+Currently uses Pytorch 1.30, FastAI 1.0.59, Librosa 0.7.1
+```
+conda install -c pytorch -c fastai fastai
+conda install -c pytorch torchaudio
+conda install -c conda-forge librosa
+```
+
+
 # Installation
 To install, run the following commands in a shell. 
 
 ```
 git clone https://github.com/mogwai/fastai_audio
 cd fastai_audio
-sudo chmod +x install.sh
-./install.sh
 ```
 
 If you wish to work in a folder other than fastai_audio, you can link the audio folder by navigating in the terminal to the folder where your notebooks are and running

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -1,7 +1,6 @@
 from IPython.display import Audio
 import mimetypes
 import torchaudio
-from torchaudio.transforms import PadTrim, DownmixMono
 from fastai.data_block import ItemBase
 from fastai.vision import Image
 import numpy as np

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -37,7 +37,8 @@ class AudioItem(ItemBase):
         self.hear(title=title)
         for i,im in enumerate(self.get_spec_images()):
             print(f"Channel {int(i//images_per_channel)}.{int(i%images_per_channel)} ({im.shape[-2]}x{im.shape[-1]}):")
-            display(im)
+            display(im.rotate(180).flip_lr())
+            
                          
     def get_spec_images(self):
         sg = self.spectro

--- a/audio/data.py
+++ b/audio/data.py
@@ -312,7 +312,7 @@ class AudioList(ItemList):
                                 not contain different number of channels. Please set downmix=true in AudioConfig or 
                                 separate files with different number of channels.''')
 
-    def add_spectro(self, fn:PathOrStr):
+    def add_spectro(self, fn:PathOrStr, from_item_lists=True):
         spectro,start,end=None,None,None
         cache_path = self._get_cache_path(fn)
         if self.config.cache and cache_path.exists():

--- a/audio/data.py
+++ b/audio/data.py
@@ -345,6 +345,7 @@ class AudioList(ItemList):
             if self.config.sg_cfg.to_db_scale: 
                 mel = AmplitudeToDB(top_db=self.config.sg_cfg.top_db)(mel)
         #mel = mel.permute(0, 2, 1)
+        mel = mel.detach()
         if self.config.standardize: 
             mel = standardize(mel)
         if self.config.delta: 

--- a/audio/data.py
+++ b/audio/data.py
@@ -11,7 +11,7 @@ from fastai.vision import *
 from fastprogress import progress_bar
 import torchaudio
 import warnings
-from torchaudio.transforms import MelSpectrogram, SpectrogramToDB, MFCC
+from torchaudio.transforms import MelSpectrogram, AmplitudeToDB, MFCC
 
 
 def md5(s):

--- a/audio/data.py
+++ b/audio/data.py
@@ -398,10 +398,10 @@ class AudioList(ItemList):
         plt.show()
   
     @classmethod
-    def from_folder(cls, path: PathOrStr = '.', extensions: Collection[str] = None, recurse: bool = True, **kwargs) -> ItemList:
-        if not extensions:
-            extensions = AUDIO_EXTENSIONS
-        return cls(get_files(path, extensions, recurse), path, **kwargs)
+    def from_folder(cls, path:PathOrStr='.', extensions:Collection[str]=None, **kwargs)->ItemList:
+        "Get the list of files in `path` that have an audio suffix. `recurse` determines if we search subfolders."
+        extensions = ifnone(extensions, AUDIO_EXTENSIONS)
+        return super().from_folder(path=path, extensions=extensions, **kwargs)
 
 def open_audio(fn:Path, after_open:Callable=None)->AudioItem:
     if not fn.exists(): raise FileNotFoundError(f"{fn}' could not be found")

--- a/audio/data.py
+++ b/audio/data.py
@@ -343,7 +343,6 @@ class AudioList(ItemList):
             mel = MelSpectrogram(**(self.config.sg_cfg.mel_args()))(item.sig)
             if self.config.sg_cfg.to_db_scale: 
                 mel = AmplitudeToDB(top_db=self.config.sg_cfg.top_db)(mel)
-        #mel = mel.permute(0, 2, 1)
         mel = mel.detach()
         if self.config.standardize: 
             mel = standardize(mel)

--- a/audio/data.py
+++ b/audio/data.py
@@ -402,6 +402,21 @@ class AudioList(ItemList):
         "Get the list of files in `path` that have an audio suffix. `recurse` determines if we search subfolders."
         extensions = ifnone(extensions, AUDIO_EXTENSIONS)
         return super().from_folder(path=path, extensions=extensions, **kwargs)
+        
+        
+    @classmethod
+    def from_df(cls, df:DataFrame, path:PathOrStr, cols:IntsOrStrs=0, folder:PathOrStr=None, suffix:str='', **kwargs)->ItemList:
+        "Get the filenames in `cols` of `df` with `folder` in front of them, `suffix` at the end."
+        suffix = suffix or ''
+        res = super().from_df(df, path=path, cols=cols, **kwargs)
+
+
+        pref = f'{res.path}{os.path.sep}'
+        if folder is not None: pref += f'{folder}{os.path.sep}'
+        res.items = np.char.add(np.char.add(pref, res.items.astype(str)), suffix)
+        return res    
+        
+        
 
 def open_audio(fn:Path, after_open:Callable=None)->AudioItem:
     if not fn.exists(): raise FileNotFoundError(f"{fn}' could not be found")

--- a/audio/data.py
+++ b/audio/data.py
@@ -274,8 +274,7 @@ class AudioLabelList(LabelList):
         super().process(*args, **kwargs)
         self.x.config._processed = True
 
-    @property
-    def c(self): return np.unique(self.y.items).shape[0]
+
 
 class AudioList(ItemList):
     _bunch = AudioDataBunch

--- a/audio/learner.py
+++ b/audio/learner.py
@@ -59,7 +59,7 @@ def _calc_channels(data:AudioDataBunch):
 
 def audio_predict(learn, item:AudioItem):
     '''Applies preprocessing to an AudioItem before predicting its class'''
-    al = AudioList([item], path=item.path, config=learn.data.x.config).split_none().label_empty()
+    al = AudioList([item], path=item.path, config=learn.data.x.config)
     ai = AudioList.open(al, item.path)
     return learn.predict(ai)                                              
 

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -240,11 +240,13 @@ def tfm_down_and_up(ai:AudioItem, sr_divisor=2, **kwargs)->AudioItem:
     sig = torch.tensor(librosa.audio.resample(down, ai.sr/sr_divisor, ai.sr))
     return AudioItem(sig,ai.sr)
 
-def tfm_pad_to_max(ai:AudioItem, mx=1000):
-    """Pad tensor with zeros (silence) until it reaches length `mx`"""
-    copy = ai.sig.clone()
-    padded = torchaudio.transforms.PadTrim(max_len=mx)(copy[None,:]).squeeze()
-    return AudioItem(padded, ai.sr)
+# Remove since torch audio does not support PadTrim any more since v0.3
+# Also, this does not seem to be used in any other code, tutorials, getting started notebooks
+#def tfm_pad_to_max(ai:AudioItem, mx=1000):
+#    """Pad tensor with zeros (silence) until it reaches length `mx`"""
+#    copy = ai.sig.clone()
+#    padded = torchaudio.transforms.PadTrim(max_len=mx)(copy[None,:]).squeeze()
+#    return AudioItem(padded, ai.sr)
 
 def tfm_pad_or_trim(ai:AudioItem, mx, trim_section="mid", pad_at_end=True, **kwargs):
     """Pad tensor with zeros (silence) until it reaches length `mx` frames, or trim clip to length `mx` frames"""
@@ -266,7 +268,7 @@ def tfm_pad_or_trim(ai:AudioItem, mx, trim_section="mid", pad_at_end=True, **kwa
     return AudioItem(sig=nsig, sr=ai.sr)
 
 def tfm_downmix(signal):
-    return DownmixMono(channels_first=True)(signal)
+    return torch.mean(signal, 0,True)
 
 
 def get_signal_transforms(white_noise:bool=True,

--- a/audio/transform.py
+++ b/audio/transform.py
@@ -240,14 +240,6 @@ def tfm_down_and_up(ai:AudioItem, sr_divisor=2, **kwargs)->AudioItem:
     sig = torch.tensor(librosa.audio.resample(down, ai.sr/sr_divisor, ai.sr))
     return AudioItem(sig,ai.sr)
 
-# Remove since torch audio does not support PadTrim any more since v0.3
-# Also, this does not seem to be used in any other code, tutorials, getting started notebooks
-#def tfm_pad_to_max(ai:AudioItem, mx=1000):
-#    """Pad tensor with zeros (silence) until it reaches length `mx`"""
-#    copy = ai.sig.clone()
-#    padded = torchaudio.transforms.PadTrim(max_len=mx)(copy[None,:]).squeeze()
-#    return AudioItem(padded, ai.sr)
-
 def tfm_pad_or_trim(ai:AudioItem, mx, trim_section="mid", pad_at_end=True, **kwargs):
     """Pad tensor with zeros (silence) until it reaches length `mx` frames, or trim clip to length `mx` frames"""
     sig = ai.sig.clone()

--- a/install.sh
+++ b/install.sh
@@ -6,4 +6,4 @@
 set -m
 pip install pydub librosa fire --user
 sudo apt-get --assume-yes install ffmpeg sox libsox-dev libsox-fmt-all
-pip install git+https://github.com/pytorch/audio.git@d92de5b97fc6204db4b1e3ed20c03ac06f5d53f0
+pip install torchaudio==0.3.0

--- a/tutorials/02_Features.ipynb
+++ b/tutorials/02_Features.ipynb
@@ -747,7 +747,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sg_cfg_tune = SpectrogramConfig(hop=256, n_mels=192)\n",
+    "sg_cfg_tune = SpectrogramConfig(hop_length=256, n_mels=192)\n",
     "config_tune.sg_cfg = sg_cfg_tune\n",
     "audios_tune = AudioList.from_folder(data_folder, config=config_tune).split_by_rand_pct(.2, seed=4).label_from_re(label_pattern)\n",
     "db_tune = audios_tune.databunch(bs=64)\n",
@@ -1229,9 +1229,9 @@
    "id": "44b813541fecdcfe05eb80093f67a97b"
   },
   "kernelspec": {
-   "display_name": "fastai",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "fastai"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1243,7 +1243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.5"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
Opening a new PR that combines fixes from my branch and the original upgrade work by @filipmu, but keeps the original install script as requested.

- Upgrade to torchaudio v0.3.0 covering issue: [mogwai/fastai_audio/issues/37]
- Added .from_df option for loading data.
- Fixed issue with ability to handle multicategory problems
- Updated the impacted Tutorial notebooks and Getting Started notebook.
- Fixed issues with `audio_predict` 
