### PR TITLE
Changes to installation requirements and prediction functions

### DIFF
--- a/audio/learner.py
+++ b/audio/learner.py
@@ -59,13 +59,13 @@ def _calc_channels(data:AudioDataBunch):
 
 def audio_predict(learn, item:AudioItem):
     '''Applies preprocessing to an AudioItem before predicting its class'''
-    al = AudioList([item], path=item.path, config=learn.data.x.config)
+    al = AudioList([Path(item.path)], path=item.path, config=learn.data.x.config)
     ai = AudioList.open(al, item.path)
     return learn.predict(ai)                                              
 
 def audio_predict_all(learn, al:AudioList):
     '''Applies preprocessing to an AudioList then predicts on all items'''
-    al = al.split_none().label_empty()
-    audioItems = [AudioList.open(al, ai[0].path) for ai in al.train]
+    al = al.split_none()
+    audioItems = [AudioList.open(al.train, ai.path) for ai in al.train]
     preds = [learn.predict(ai) for ai in progress_bar(audioItems)]
     return [o for o in zip(*preds)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastai
 torch==1.4.0
 torchvision==0.5
-torchaudio==0.5.0
+torchaudio==0.4.0
 pydub
 librosa
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 fastai
-torchaudio
+torch==1.4.0
+torchvision==0.5
+torchaudio==0.5.0
 pydub
 librosa
 matplotlib


### PR DESCRIPTION
#1 Changes to installation requirements
To get fastai audio working, I needed to specify older PyTorch versions, as I was getting this error with the most recent PyTorch version (the other version changes to torchvision and torchaudio were needed to support the 1.4.0 version).

`databunch to float RuntimeError: Expected object of scalar type Float but got scalar type Double for argument #3 'mat2' in call to _th_addmm_out` 


#2 Changes to learner.py
I noticed audio_predict and audio_predict_all functions were failing when I tried to follow a tutorial. I noticed recent changes modified the expected behavior of AudioList class and functions which were directly or indirectly called while executing these functions (audio_predict and audio_predict_all).

I modified the arguments to AudioList constructor and the AudioList.open function to make it work. Some sort of unit test may help catch some of these minor errors.

